### PR TITLE
Add `blocking` and `with_reqeust_blocking` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 repository = "https://github.com/maoertel/prometheus-push"
 
 [package.metadata.docs.rs]
-features = ["with_reqwest"]
+features = ["blocking", "with_reqwest", "with_reqwest_blocking"]
 
 [dependencies]
 async-trait = "0.1"
@@ -20,4 +20,6 @@ log = { version = "0.4", default-features = false, optional = true }
 
 [features]
 default = []
+blocking = []
 with_reqwest = ["reqwest", "log"]
+with_reqwest_blocking = ["blocking", "reqwest/blocking", "log"]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# Prometheus async push
+# Prometheus push
 
-This crate works as an extension to the [prometheus](https://crates.io/crates/prometheus) crate to be able to push non-blocking to your
-Prometheus push gateway and with a less dependent setup of `reqwest` (no `openssl` for example). Parts of the logic in this repo were
-taken but rewritten from the blocking `push` feature in the above mentioned `prometheus` crate.
+This crate works as an extension to the [prometheus](https://crates.io/crates/prometheus) crate to be able to push non-blocking (default) to your
+Prometheus push gateway and with a less dependent setup of `reqwest` (no `openssl` for example) or with an implementation of your own http client.
 
 By default you have to implement the `Push` trait to use it with your choice of http client or you can use the `with_request` feature.
 This feature implements `Push` in a `PushClient` that leverages `reqwest` under the hood. Reqwest is setup without default features 
 (minimal set) so it should not interfere with your reqwest setup (e.g. `rust-tls`).
+
+Async functionality is considered the standard in this crate but you can enable the `blocking` feature to get the implementation without async. YourClient
+can enable the corresponding blocking `reqwest` implementation with the `with_request_blocking` feature.
 
 ## Example with feature `with_reqwest`
 
@@ -52,6 +54,13 @@ impl Push for YourClient {
     }
 }
 ```
+
+## features
+
+- `default`: by default async functionality and no reqwest is enabled
+- `with_request`: this feature enables `reqwest` in minimal configuration and enables the alredy implemented `PushClient`
+- `blocking`: on top of the default feature you get the same functionality in a blocking fashion
+- `with_reqwest_blocking`: like `with_reqwest` but including blocking and completely blocking
 
 ## License
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -10,13 +10,13 @@ use prometheus::Encoder;
 #[cfg(feature = "with_reqwest_blocking")]
 use reqwest::blocking::Client;
 
-use crate::PushType;
 #[cfg(feature = "with_reqwest_blocking")]
 use crate::blocking::with_request::PushClient;
 use crate::error::Result;
 use crate::helper::create;
 use crate::helper::metric_families_from;
 use crate::helper::validate_url;
+use crate::PushType;
 
 pub trait Push {
     fn push_all(&self, url: &str, body: Vec<u8>, content_type: &str) -> Result<()>;

--- a/src/blocking/with_request.rs
+++ b/src/blocking/with_request.rs
@@ -1,0 +1,55 @@
+use reqwest::blocking::Client;
+use reqwest::blocking::Response;
+use reqwest::header::CONTENT_TYPE;
+use reqwest::StatusCode;
+
+use crate::blocking::Push;
+use crate::error::PushMetricsError;
+use crate::error::Result;
+
+pub struct PushClient {
+    client: Client,
+}
+
+impl PushClient {
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+impl Push for PushClient {
+    fn push_all(&self, url: &str, body: Vec<u8>, content_type: &str) -> Result<()> {
+        let response = &self
+            .client
+            .put(url)
+            .header(CONTENT_TYPE, content_type)
+            .body(body)
+            .send()?;
+
+        handle_response(response)
+    }
+
+    fn push_add(&self, url: &str, body: Vec<u8>, content_type: &str) -> Result<()> {
+        let response = &self
+            .client
+            .post(url)
+            .header(CONTENT_TYPE, content_type)
+            .body(body)
+            .send()?;
+
+        handle_response(response)
+    }
+}
+
+fn handle_response(response: &Response) -> Result<()> {
+    match response.status() {
+        StatusCode::ACCEPTED | StatusCode::OK => {
+            log::info!("Pushed metrics to the push gateway.");
+            Ok(())
+        }
+        status_code => Err(PushMetricsError::Generic(format!(
+            "unexpected status code {status_code} while pushing to {url}",
+            url = response.url()
+        ))),
+    }
+}

--- a/src/blocking/with_request.rs
+++ b/src/blocking/with_request.rs
@@ -4,8 +4,9 @@ use reqwest::header::CONTENT_TYPE;
 use reqwest::StatusCode;
 
 use crate::blocking::Push;
-use crate::error::PushMetricsError;
 use crate::error::Result;
+use crate::helper::handle_response;
+use crate::helper::Respond;
 
 pub struct PushClient {
     client: Client,
@@ -41,15 +42,12 @@ impl Push for PushClient {
     }
 }
 
-fn handle_response(response: &Response) -> Result<()> {
-    match response.status() {
-        StatusCode::ACCEPTED | StatusCode::OK => {
-            log::info!("Pushed metrics to the push gateway.");
-            Ok(())
-        }
-        status_code => Err(PushMetricsError::Generic(format!(
-            "unexpected status code {status_code} while pushing to {url}",
-            url = response.url()
-        ))),
+impl Respond for Response {
+    fn get_status_code(&self) -> StatusCode {
+        self.status()
+    }
+
+    fn get_url(&self) -> &reqwest::Url {
+        self.url()
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,10 +6,9 @@ pub type Result<T> = std::result::Result<T, PushMetricsError>;
 #[derive(Debug)]
 pub enum PushMetricsError {
     Prometheus(prometheus::Error),
-
-    #[cfg(feature = "with_reqwest")]
-    Reqwest(reqwest::Error),
     Generic(String),
+    #[cfg(any(feature = "with_reqwest", feature = "with_reqwest_blocking"))]
+    Reqwest(reqwest::Error),
 }
 
 impl std::error::Error for PushMetricsError {}
@@ -19,7 +18,7 @@ impl fmt::Display for PushMetricsError {
         match self {
             PushMetricsError::Prometheus(e) => std::fmt::Display::fmt(e, f),
             PushMetricsError::Generic(e) => std::fmt::Display::fmt(e, f),
-            #[cfg(feature = "with_reqwest")]
+            #[cfg(any(feature = "with_reqwest", feature = "with_reqwest_blocking"))]
             PushMetricsError::Reqwest(e) => std::fmt::Display::fmt(e, f),
         }
     }
@@ -31,7 +30,7 @@ impl From<prometheus::Error> for PushMetricsError {
     }
 }
 
-#[cfg(feature = "with_reqwest")]
+#[cfg(any(feature = "with_reqwest", feature = "with_reqwest_blocking"))]
 impl From<reqwest::Error> for PushMetricsError {
     fn from(error: reqwest::Error) -> Self {
         PushMetricsError::Reqwest(error)

--- a/src/with_request.rs
+++ b/src/with_request.rs
@@ -1,11 +1,11 @@
+use crate::error::Result;
+use crate::helper::handle_response;
+use crate::helper::Respond;
+use crate::Push;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
 use reqwest::Response;
 use reqwest::StatusCode;
-
-use crate::error::PushMetricsError;
-use crate::error::Result;
-use crate::Push;
 
 pub struct PushClient {
     client: Client,
@@ -44,15 +44,12 @@ impl Push for PushClient {
     }
 }
 
-fn handle_response(response: &Response) -> Result<()> {
-    match response.status() {
-        StatusCode::ACCEPTED | StatusCode::OK => {
-            log::info!("Pushed metrics to the push gateway.");
-            Ok(())
-        }
-        status_code => Err(PushMetricsError::Generic(format!(
-            "unexpected status code {status_code} while pushing to {url}",
-            url = response.url()
-        ))),
+impl Respond for Response {
+    fn get_status_code(&self) -> StatusCode {
+        self.status()
+    }
+
+    fn get_url(&self) -> &reqwest::Url {
+        self.url()
     }
 }


### PR DESCRIPTION
To be able to push with a blocking client this functionality was added as a `blocking` feature. Additionally the `reqwest/blocking` feature was implemented so a default blocking client can be used with the `with_reqwest_blocking` feature.