### PR TITLE
Use `Url` instead of `str`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ features = ["blocking", "with_reqwest", "with_reqwest_blocking"]
 [dependencies]
 async-trait = "0.1"
 prometheus = "0.13"
+url = "2.4"
 reqwest = { version = "0.11", default-features = false, optional = true }
 log = { version = "0.4", default-features = false, optional = true }
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ use prometheus::labels;
 use prometheus_push::with_request::PushClient;
 use prometheus_push::MetricsPusher;
 use reqwest::Client;
+use url::Url;
 
-let push_gateway = "<address to your instance>";
-let metrics_pusher = MetricsPusher::<PushClient>::from(Client::new(), &push_gateway);
+let push_gateway: Url = <address to your instance>;
+let metrics_pusher = MetricsPusher::<PushClient>::from(Client::new(), &push_gateway)?;
 metrics_pusher
   .push_all(
     "<your push jobs name>",
@@ -39,6 +40,7 @@ Basically it is as simple as that.
 
 ```rust
 use prometheus_push::Push;
+...
 
 pub struct YourClient {
     ...
@@ -46,11 +48,11 @@ pub struct YourClient {
 
 #[async_trait::async_trait]
 impl Push for YourClient {
-    async fn push_all(&self, url: &str, body: Vec<u8>, content_type: &str) -> Result<()> {
+    async fn push_all(&self, url: &Url, body: Vec<u8>, content_type: &str) -> Result<()> {
         // implement a PUT request with your client with this body and `content_type` in header
     }
 
-    async fn push_add(&self, url: &str, body: Vec<u8>, content_type: &str) -> Result<()> {
+    async fn push_add(&self, url: &Url, body: Vec<u8>, content_type: &str) -> Result<()> {
         // implement a POST request with your client with this body and `content_type` in header
     }
 }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -24,6 +24,7 @@ pub trait Push {
     fn push_add(&self, url: &Url, body: Vec<u8>, content_type: &str) -> Result<()>;
 }
 
+#[derive(Debug)]
 pub struct MetricsPusher<P: Push> {
     push_client: P,
     url: Url,

--- a/src/blocking/with_request.rs
+++ b/src/blocking/with_request.rs
@@ -2,6 +2,7 @@ use reqwest::blocking::Client;
 use reqwest::blocking::Response;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::StatusCode;
+use url::Url;
 
 use crate::blocking::Push;
 use crate::error::Result;
@@ -19,10 +20,10 @@ impl PushClient {
 }
 
 impl Push for PushClient {
-    fn push_all(&self, url: &str, body: Vec<u8>, content_type: &str) -> Result<()> {
+    fn push_all(&self, url: &Url, body: Vec<u8>, content_type: &str) -> Result<()> {
         let response = &self
             .client
-            .put(url)
+            .put(url.as_str())
             .header(CONTENT_TYPE, content_type)
             .body(body)
             .send()?;
@@ -30,10 +31,10 @@ impl Push for PushClient {
         handle_response(response)
     }
 
-    fn push_add(&self, url: &str, body: Vec<u8>, content_type: &str) -> Result<()> {
+    fn push_add(&self, url: &Url, body: Vec<u8>, content_type: &str) -> Result<()> {
         let response = &self
             .client
-            .post(url)
+            .post(url.as_str())
             .header(CONTENT_TYPE, content_type)
             .body(body)
             .send()?;
@@ -47,7 +48,7 @@ impl Respond for Response {
         self.status()
     }
 
-    fn get_url(&self) -> &reqwest::Url {
+    fn get_url(&self) -> &Url {
         self.url()
     }
 }

--- a/src/blocking/with_request.rs
+++ b/src/blocking/with_request.rs
@@ -9,6 +9,7 @@ use crate::error::Result;
 use crate::helper::handle_response;
 use crate::helper::Respond;
 
+#[derive(Debug)]
 pub struct PushClient {
     client: Client,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ pub type Result<T> = std::result::Result<T, PushMetricsError>;
 #[derive(Debug)]
 pub enum PushMetricsError {
     Prometheus(prometheus::Error),
+    Url(url::ParseError),
     Generic(String),
     #[cfg(any(feature = "with_reqwest", feature = "with_reqwest_blocking"))]
     Reqwest(reqwest::Error),
@@ -17,6 +18,7 @@ impl fmt::Display for PushMetricsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             PushMetricsError::Prometheus(e) => std::fmt::Display::fmt(e, f),
+            PushMetricsError::Url(e) => std::fmt::Display::fmt(e, f),
             PushMetricsError::Generic(e) => std::fmt::Display::fmt(e, f),
             #[cfg(any(feature = "with_reqwest", feature = "with_reqwest_blocking"))]
             PushMetricsError::Reqwest(e) => std::fmt::Display::fmt(e, f),
@@ -27,6 +29,12 @@ impl fmt::Display for PushMetricsError {
 impl From<prometheus::Error> for PushMetricsError {
     fn from(prometheus_error: prometheus::Error) -> Self {
         PushMetricsError::Prometheus(prometheus_error)
+    }
+}
+
+impl From<url::ParseError> for PushMetricsError {
+    fn from(error: url::ParseError) -> Self {
+        PushMetricsError::Url(error)
     }
 }
 

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -60,7 +60,7 @@ fn build_url<'a, BH: BuildHasher>(
     job: &'a str,
     grouping: &'a HashMap<&'a str, &'a str, BH>,
 ) -> Result<Url> {
-    let mut url = url.join(&format!("{job}/"))?;
+    let mut url_params = vec![job];
 
     for (label_name, label_value) in grouping {
         if label_value.contains('/') {
@@ -68,10 +68,11 @@ fn build_url<'a, BH: BuildHasher>(
                 "value of grouping label {label_name} contains '/': {label_value}",
             )));
         }
-        url = url.join(&format!("{label_name}/{label_value}/"))?;
+        url_params.push(label_name);
+        url_params.push(label_value);
     }
 
-    Ok(url)
+    Ok(url.join(&url_params.join("/"))?)
 }
 
 fn encode_metrics<'a, BH: BuildHasher>(

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -8,31 +8,24 @@ use prometheus::ProtobufEncoder;
 use prometheus::Registry;
 #[cfg(any(feature = "with_reqwest", feature = "with_reqwest_blocking"))]
 use reqwest::StatusCode;
+use url::Url;
 
 use crate::error::PushMetricsError;
 use crate::error::Result;
 
 const LABEL_NAME_JOB: &str = "job";
+const METRICS_JOB_PATH: &str = "metrics/job";
 
-pub(crate) fn validate_url(url: &str) -> String {
-    let mut slash = "/";
-    let mut scheme = "http://";
-    if url.contains("://") {
-        scheme = ""
-    };
-    if url.ends_with('/') {
-        slash = ""
-    };
-
-    format!("{scheme}{url}{slash}metrics/job")
+pub(crate) fn create_metrics_job_url(url: &Url) -> Result<Url> {
+    Ok(url.join(METRICS_JOB_PATH)?)
 }
 
 pub(crate) fn create<'a, BH: BuildHasher>(
     job: &'a str,
-    url: &'a str,
+    url: &'a Url,
     grouping: &HashMap<&str, &str, BH>,
     metric_families: Vec<MetricFamily>,
-) -> Result<(String, Vec<u8>, ProtobufEncoder)> {
+) -> Result<(Url, Vec<u8>, ProtobufEncoder)> {
     let job = validate_job(job)?;
     let url = build_url(url, job, grouping)?;
     let encoder = ProtobufEncoder::new();
@@ -63,22 +56,21 @@ fn validate_job(job: &str) -> Result<&str> {
 }
 
 fn build_url<'a, BH: BuildHasher>(
-    url: &'a str,
+    url: &'a Url,
     job: &'a str,
     grouping: &'a HashMap<&'a str, &'a str, BH>,
-) -> Result<String> {
-    let mut url_params = vec![job];
+) -> Result<Url> {
+    let mut url = url.join(job)?;
+
     for (label_name, label_value) in grouping {
         if label_value.contains('/') {
             return Err(PushMetricsError::Generic(format!(
                 "value of grouping label {label_name} contains '/': {label_value}",
             )));
         }
-        url_params.push(label_name);
-        url_params.push(label_value);
+        url = url.join(label_name)?;
+        url = url.join(label_value)?;
     }
-
-    let url = format!("{url}/{params}", params = url_params.join("/"));
 
     Ok(url)
 }
@@ -119,7 +111,7 @@ fn encode_metrics<'a, BH: BuildHasher>(
 #[cfg(any(feature = "with_reqwest", feature = "with_reqwest_blocking"))]
 pub(crate) trait Respond {
     fn get_status_code(&self) -> StatusCode;
-    fn get_url(&self) -> &reqwest::Url;
+    fn get_url(&self) -> &Url;
 }
 
 #[cfg(any(feature = "with_reqwest", feature = "with_reqwest_blocking"))]

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -60,7 +60,7 @@ fn build_url<'a, BH: BuildHasher>(
     job: &'a str,
     grouping: &'a HashMap<&'a str, &'a str, BH>,
 ) -> Result<Url> {
-    let mut url = url.join(job)?;
+    let mut url = url.join(&format!("{job}/"))?;
 
     for (label_name, label_value) in grouping {
         if label_value.contains('/') {
@@ -68,8 +68,7 @@ fn build_url<'a, BH: BuildHasher>(
                 "value of grouping label {label_name} contains '/': {label_value}",
             )));
         }
-        url = url.join(label_name)?;
-        url = url.join(label_value)?;
+        url = url.join(&format!("{label_name}/{label_value}/"))?;
     }
 
     Ok(url)

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -14,7 +14,7 @@ use crate::error::PushMetricsError;
 use crate::error::Result;
 
 const LABEL_NAME_JOB: &str = "job";
-const METRICS_JOB_PATH: &str = "metrics/job";
+const METRICS_JOB_PATH: &str = "metrics/job/";
 
 pub(crate) fn create_metrics_job_url(url: &Url) -> Result<Url> {
     Ok(url.join(METRICS_JOB_PATH)?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ enum PushType {
     All,
 }
 
+#[derive(Debug)]
 pub struct MetricsPusher<P: Push> {
     push_client: P,
     url: Url,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,18 +13,19 @@ use prometheus::proto::MetricFamily;
 use prometheus::Encoder;
 #[cfg(feature = "with_reqwest")]
 use reqwest::Client;
+use url::Url;
 
 use crate::error::Result;
 use crate::helper::create;
+use crate::helper::create_metrics_job_url;
 use crate::helper::metric_families_from;
-use crate::helper::validate_url;
 #[cfg(feature = "with_reqwest")]
 use crate::with_request::PushClient;
 
 #[async_trait::async_trait]
 pub trait Push {
-    async fn push_all(&self, url: &str, body: Vec<u8>, content_type: &str) -> Result<()>;
-    async fn push_add(&self, url: &str, body: Vec<u8>, content_type: &str) -> Result<()>;
+    async fn push_all(&self, url: &Url, body: Vec<u8>, content_type: &str) -> Result<()>;
+    async fn push_add(&self, url: &Url, body: Vec<u8>, content_type: &str) -> Result<()>;
 }
 
 enum PushType {
@@ -34,17 +35,17 @@ enum PushType {
 
 pub struct MetricsPusher<P: Push> {
     push_client: P,
-    url: String,
+    url: Url,
 }
 
 impl<P: Push> MetricsPusher<P> {
-    pub fn new(push_client: P, url: &str) -> MetricsPusher<P> {
-        let url = validate_url(url);
-        Self { push_client, url }
+    pub fn new(push_client: P, url: &Url) -> Result<MetricsPusher<P>> {
+        let url = create_metrics_job_url(url)?;
+        Ok(Self { push_client, url })
     }
 
     #[cfg(feature = "with_reqwest")]
-    pub fn from(client: Client, url: &str) -> MetricsPusher<PushClient> {
+    pub fn from(client: Client, url: &Url) -> Result<MetricsPusher<PushClient>> {
         MetricsPusher::new(PushClient::new(client), url)
     }
 

--- a/src/with_request.rs
+++ b/src/with_request.rs
@@ -6,6 +6,7 @@ use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
 use reqwest::Response;
 use reqwest::StatusCode;
+use url::Url;
 
 pub struct PushClient {
     client: Client,
@@ -19,10 +20,10 @@ impl PushClient {
 
 #[async_trait::async_trait]
 impl Push for PushClient {
-    async fn push_all(&self, url: &str, body: Vec<u8>, content_type: &str) -> Result<()> {
+    async fn push_all(&self, url: &Url, body: Vec<u8>, content_type: &str) -> Result<()> {
         let response = &self
             .client
-            .put(url)
+            .put(url.as_str())
             .header(CONTENT_TYPE, content_type)
             .body(body)
             .send()
@@ -31,10 +32,10 @@ impl Push for PushClient {
         handle_response(response)
     }
 
-    async fn push_add(&self, url: &str, body: Vec<u8>, content_type: &str) -> Result<()> {
+    async fn push_add(&self, url: &Url, body: Vec<u8>, content_type: &str) -> Result<()> {
         let response = &self
             .client
-            .post(url)
+            .post(url.as_str())
             .header(CONTENT_TYPE, content_type)
             .body(body)
             .send()
@@ -49,7 +50,7 @@ impl Respond for Response {
         self.status()
     }
 
-    fn get_url(&self) -> &reqwest::Url {
+    fn get_url(&self) -> &Url {
         self.url()
     }
 }

--- a/src/with_request.rs
+++ b/src/with_request.rs
@@ -8,6 +8,7 @@ use reqwest::Response;
 use reqwest::StatusCode;
 use url::Url;
 
+#[derive(Debug)]
 pub struct PushClient {
     client: Client,
 }


### PR DESCRIPTION
To not validate an url itself and get rid of all the clutter, let's use the `url` crate.