### PR TITLE
Extend documentation with common scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,36 @@
-# Prometheus Push
+# Prometheus Push :arrow_double_up:
 
-`prometheus_push` works as an extension to prometheus crates like [prometheus](https://crates.io/crates/prometheus) to be able to push non-blocking (default)
-or blocking to your Prometheus pushgateway and with a less dependent setup of `reqwest` (no `openssl` for example) or with an implementation of your
-own http client.
+`prometheus_push` works as an extension to prometheus crates like [prometheus](https://crates.io/crates/prometheus) or
+[prometheus-client](https://crates.io/crates/prometheus-client) to be able to push non-blocking (default) or blocking to your Prometheus
+pushgateway with a less dependent setup of `reqwest` (no `openssl` for example) or with an implementation of your own http client or even
+another `prometheus` crate – this whole crate is completely generic so you are free to do whatever you want.
 
-By default you have to implement the `Push` trait to use it with your choice of http client or you can use the `with_reqwest` feature.
-This feature already implements `Push` in a `PushClient` that leverages `reqwest` under the hood. Reqwest is setup without default features
-(minimal set) in this case so it should not interfere with your own applications reqwest setup (e.g. `rust-tls`).
+If you wanna use it with `reqwest`, `prometheus` or `prometheus-client` crates you literally do not have to implement anything (see
+[scenarios](#scenarios) below), as those common usages are already implemented as features within this crate.
 
-Async functionality is considered the standard in this crate but you can enable the `blocking` feature to get the implementation without async. You
-can enable the corresponding blocking `reqwest` implementation with the `with_reqwest_blocking` feature in which case you enable the `blocking`
-feature of the `reqwest` crate.
+In this crates stripped version you have to implement the `Push` trait (see [here](#implement-push-yourself)) to use it with your choice of
+http client or –as said– you can use the `with_reqwest` or `with_reqwest_blocking` features. These features already implement `Push` in a
+`PushClient` that leverages `reqwest` under the hood. Reqwest is set up without default features (minimal set) in this case so it should
+not interfere with your own applications reqwest setup (e.g. `rust-tls`).
 
-In terms of the underlying prometheus functionality you have to implement the `ConvertMetrics` trait or you use the already implemented feature
-`prometheus_crate` that leverages the [prometheus](https://crates.io/crates/prometheus) crate
-or `prometheus_client_crate` that uses the [prometheus-client](https://crates.io/crates/prometheus-client) crate.
+Async functionality (feature `non_blocking`) is considered the standard in this crate but you can enable the `blocking` feature to get the
+implementation without async. You can enable the corresponding blocking `reqwest` implementation with the `with_reqwest_blocking` feature in
+which case you enable the `blocking` feature of the `reqwest` crate.
 
-## Example with features `with_reqwest` and `prometheus_crate`
+In terms of the underlying prometheus functionality you have to implement the `ConvertMetrics` trait  yourself (see [here](#implement-convertmetrics-yourself))
+or you use the already implemented feature `prometheus_crate` that leverages the [prometheus](https://crates.io/crates/prometheus) crate or
+`prometheus_client_crate` that uses the [prometheus-client](https://crates.io/crates/prometheus-client) crate.
+
+## Scenarios
+
+### 1. I use `reqwest` and `prometheus` crates in a **non-blocking** fashion
+
+In your `Cargo.toml`:
+
+```toml
+[dependencies]
+prometheus_push = { version = "<version>", default-features = false, features = ["with_reqwest", "prometheus_crate"] }
+```
 
 ```rust
 use prometheus::labels;
@@ -24,26 +38,135 @@ use prometheus_push::prometheus_crate::PrometheusMetricsPusher;
 use reqwest::Client;
 use url::Url;
 
-let push_gateway: Url = "<address to your instance>";
-let client = Client::new();
-let metrics_pusher = PrometheusMetricsPusher::from(client, &push_gateway)?;
-metrics_pusher
-  .push_all(
-    "<your push jobs name>",
-    &labels! { "<label_name>" => "<label_value>" },
-    prometheus::gather(),
-  )
-  .await?;
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let push_gateway: Url = Url::parse("<address to pushgateway>")?;
+    let client = Client::new();
+    let metrics_pusher = PrometheusMetricsPusher::from(client, &push_gateway)?;
+    metrics_pusher
+        .push_all(
+            "<your push jobs name>",
+            &labels! { "<label_name>" => "<label_value>" },
+            prometheus::gather(),
+        )
+        .await?;
+
+    Ok(())
+}
 ```
 
-## Implement `Push` yourself
+### 2. I use `reqwest` and `prometheus` crates in a **blocking** fashion
+
+In your `Cargo.toml`:
+
+```toml
+[dependencies]
+prometheus_push = { version = "<version>", default-features = false, features = ["with_reqwest_blocking", "prometheus_crate"] }
+```
+
+```rust
+use prometheus::labels;
+use prometheus_push::prometheus_crate::PrometheusMetricsPusherBlocking;
+use reqwest::blocking::Client;
+use url::Url;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let push_gateway: Url = Url::parse("<address to pushgateway>")?;
+    let client = Client::new();
+    let metrics_pusher = PrometheusMetricsPusherBlocking::from(client, &push_gateway)?;
+    metrics_pusher
+        .push_all(
+            "<your push jobs name>",
+            &labels! { "<label_name>" => "<label_value>" },
+            prometheus::gather(),
+        )?;
+
+    Ok(())
+}
+```
+
+### 3. I use `reqwest` and `prometheus-client` crates in a **non-blocking** fashion
+
+In your `Cargo.toml`:
+
+```toml
+[dependencies]
+prometheus_push = { version = "<version>", default-features = false, features = ["with_reqwest", "prometheus_client_crate"] }
+```
+
+```rust
+use prometheus_client::encoding::text::encode;
+use prometheus_push::prometheus_client_crate::PrometheusClientMetricsPusher;
+use reqwest::Client;
+use url::Url;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let push_gateway: Url = Url::parse("<address to pushgateway>")?;
+    let client = Client::new();
+    let metrics_pusher = PrometheusClientMetricsPusher::from(client, &push_gateway)?;
+    let grouping: HashMap<&str, &str> = HashMap::from([("<label_name>", "<label_value>")]);
+    let mut metrics = String::new();
+    encode(&mut metrics, &registry)?;
+
+    metrics_pusher
+        .push_all(
+            "<your push jobs name>",
+            &grouping,
+            metrics,
+        )
+        .await?;
+
+    Ok(())
+}
+```
+
+### 4. I use `reqwest` and `prometheus-client` crates in a **blocking** fashion
+
+In your `Cargo.toml`:
+
+```toml
+[dependencies]
+prometheus_push = { version = "<version>", default-features = false, features = ["with_reqwest_blocking", "prometheus_client_crate"] }
+```
+
+```rust
+use prometheus_client::encoding::text::encode;
+use prometheus_push::prometheus_client_crate::PrometheusClientMetricsPusherBlocking;
+use reqwest::blocking::Client;
+use url::Url;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let push_gateway: Url = Url::parse("<address to pushgateway>")?;
+    let client = Client::new();
+    let metrics_pusher = PrometheusClientMetricsPusherBlocking::from(client, &push_gateway)?;
+    let grouping: HashMap<&str, &str> = HashMap::from([("<label_name>", "<label_value>")]);
+    let mut metrics = String::new();
+    encode(&mut metrics, &registry)?;
+
+    metrics_pusher
+        .push_all(
+            "<your push jobs name>",
+            &grouping,
+            metrics,
+        )?;
+
+    Ok(())
+}
+```
+
+### 5. I want to implement everything myself
+
+In case you wanna implement everything yourself you can do so by implementing the `Push` trait and the `ConvertMetrics` trait.
+
+#### Implement `Push` yourself
 
 If you are not using reqwest as an http client you are free to implement the `Push` traits two methods yourself. As a guide you can use the
 implementation of the `with_reqwest` feature (see [here](https://github.com/maoertel/prometheus-push/blob/7fe1946dd143f4870beb80e642b0acb7854a3cb8/src/with_reqwest.rs)).
 Basically it is as simple as that.
 
 ```rust
-use prometheus_push::non_blocking::Push;
+use prometheus_push::Push;
 
 pub struct YourPushClient;
 
@@ -59,7 +182,7 @@ impl Push<Vec<u8>> for YourPushClient {
 }
 ```
 
-## Implement `ConvertMetrics` yourself
+#### Implement `ConvertMetrics` yourself
 
 In case you want to use another prometheus client implementation you can implement your own type that implements
 the `ConvertMetrics` trait to inject it into your instance of `MetricsPusher`.
@@ -85,6 +208,7 @@ impl ConvertMetrics<Vec<YourMetricFamily>, Vec<Box<dyn YourCollector>>, Vec<u8>>
     }
 }
 ```
+
 ## Features
 
 - `default`: by default async functionality and no reqwest is enabled
@@ -96,13 +220,6 @@ impl ConvertMetrics<Vec<YourMetricFamily>, Vec<Box<dyn YourCollector>>, Vec<u8>>
 - `prometheus_client_crate`: enables the functionality of the [prometheus-client](https://crates.io/crates/prometheus-client) crate
 
 ## Integration in your `Cargo.toml`
-
-Let's say you wanna use it with `reqwest` in an async fashion with the `prometheus` crate, you have to add the following to your `Cargo.toml`:
-
-```toml
-[dependencies]
-prometheus_push = { version = "<version>", default-features = false, features = ["with_reqwest", "prometheus_crate"] }
-```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -219,8 +219,6 @@ impl ConvertMetrics<Vec<YourMetricFamily>, Vec<Box<dyn YourCollector>>, Vec<u8>>
 - `prometheus_crate`: enables the functionality of the [prometheus](https://crates.io/crates/prometheus) crate
 - `prometheus_client_crate`: enables the functionality of the [prometheus-client](https://crates.io/crates/prometheus-client) crate
 
-## Integration in your `Cargo.toml`
-
 ## License
 
 [MIT](./LICENSE-MIT)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,36 @@
 //! # Prometheus Push
 //!
-//! `prometheus_push` works as an extension to prometheus crates like [prometheus](https://crates.io/crates/prometheus) to be able to push non-blocking (default)
-//! or blocking to your Prometheus pushgateway and with a less dependent setup of `reqwest` (no `openssl` for example) or with an implementation of your
-//! own http client.
+//! `prometheus_push` works as an extension to prometheus crates like [prometheus](https://crates.io/crates/prometheus) or
+//! [prometheus-client](https://crates.io/crates/prometheus-client) to be able to push non-blocking (default) or blocking to your Prometheus
+//! pushgateway with a less dependent setup of `reqwest` (no `openssl` for example) or with an implementation of your own http client or even
+//! another `prometheus` crate – this whole crate is completely generic so you are free to do whatever you want.
 //!
-//! By default you have to implement the `Push` trait to use it with your choice of http client or you can use the `with_reqwest` feature.
-//! This feature already implements `Push` in a `PushClient` that leverages `reqwest` under the hood. Reqwest is setup without default features
-//! (minimal set) in this case so it should not interfere with your own applications reqwest setup (e.g. `rust-tls`).
+//! If you wanna use it with `reqwest`, `prometheus` or `prometheus-client` crates you literally do not have to implement anything (see
+//! below), as those common usages are already implemented as features within this crate.
 //!
-//! Async functionality is considered the standard in this crate but you can enable the `blocking` feature to get the implementation without async. You
-//! can enable the corresponding blocking `reqwest` implementation with the `with_reqwest_blocking` feature in which case you enable the `blocking`
-//! feature of the `reqwest` crate.
+//! In this crates stripped version you have to implement the `Push` trait (see below) to use it with your choice of
+//! http client or –as said– you can use the `with_reqwest` or `with_reqwest_blocking` features. These features already implement `Push` in a
+//! `PushClient` that leverages `reqwest` under the hood. Reqwest is set up without default features (minimal set) in this case so it should
+//! not interfere with your own applications reqwest setup (e.g. `rust-tls`).
 //!
-//! In terms of the underlying prometheus functionality you have to implement the `ConvertMetrics` trait or you use the already implemented feature
-//! `prometheus_crate` that leverages the [prometheus](https://crates.io/crates/prometheus) crate
-//! or `prometheus_client_crate` that uses the [prometheus-client](https://crates.io/crates/prometheus-client) crate.
+//! Async functionality (feature `non_blocking`) is considered the standard in this crate but you can enable the `blocking` feature to get the
+//! implementation without async. You can enable the corresponding blocking `reqwest` implementation with the `with_reqwest_blocking` feature in
+//! which case you enable the `blocking` feature of the `reqwest` crate.
 //!
-//! ## Example with features `with_reqwest` and `prometheus_crate`
+//! In terms of the underlying prometheus functionality you have to implement the `ConvertMetrics` trait  yourself (see below)
+//! or you use the already implemented feature `prometheus_crate` that leverages the [prometheus](https://crates.io/crates/prometheus) crate or
+//! `prometheus_client_crate` that uses the [prometheus-client](https://crates.io/crates/prometheus-client) crate.
+//!
+//! ## Scenarios
+//!
+//! ### 1. I use `reqwest` and `prometheus` crates in a **non-blocking** fashion
+//!
+//! In your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! prometheus_push = { version = "<version>", default-features = false, features = ["with_reqwest", "prometheus_crate"] }
+//! ```
 //!
 //! ```ignore
 //! use prometheus::labels;
@@ -24,27 +38,135 @@
 //! use reqwest::Client;
 //! use url::Url;
 //!
-//! let push_gateway: Url = "<address to your instance>";
-//! let client = Client::new();
-//! let metrics_pusher = PrometheusMetricsPusher::from(client, &push_gateway)?;
-//! metrics_pusher
-//!   .push_all(
-//!     "<your push jobs name>",
-//!     &labels! { "<label_name>" => "<label_value>" },
-//!     prometheus::gather(),
-//!   )
-//!   .await?;
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!    let push_gateway: Url = Url::parse("<address to pushgateway>")?;
+//!    let client = Client::new();
+//!    let metrics_pusher = PrometheusMetricsPusher::from(client, &push_gateway)?;
+//!    metrics_pusher
+//!        .push_all(
+//!            "<your push jobs name>",
+//!            &labels! { "<label_name>" => "<label_value>" },
+//!            prometheus::gather(),
+//!         )
+//!         .await?;
+//!
+//!     Ok(())
+//! }
 //! ```
 //!
-//! ## Implement `Push` yourself
+//!### 2. I use `reqwest` and `prometheus` crates in a **blocking** fashion
+//!
+//!In your `Cargo.toml`:
+//!
+//!```toml
+//![dependencies]
+//!prometheus_push = { version = "<version>", default-features = false, features = ["with_reqwest_blocking", "prometheus_crate"] }
+//!```
+
+//!```ignore
+//!use prometheus::labels;
+//! use prometheus_push::prometheus_crate::PrometheusMetricsPusherBlocking;
+//! use reqwest::blocking::Client;
+//! use url::Url;
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let push_gateway: Url = Url::parse("<address to pushgateway>")?;
+//!     let client = Client::new();
+//!     let metrics_pusher = PrometheusMetricsPusherBlocking::from(client, &push_gateway)?;
+//!     metrics_pusher
+//!         .push_all(
+//!             "<your push jobs name>",
+//!             &labels! { "<label_name>" => "<label_value>" },
+//!             prometheus::gather(),
+//!         )?;
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ### 3. I use `reqwest` and `prometheus-client` crates in a **non-blocking** fashion
+//!
+//! In your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! prometheus_push = { version = "<version>", default-features = false, features = ["with_reqwest", "prometheus_client_crate"] }
+//! ```
+
+//! ```ignore
+//! use prometheus_client::encoding::text::encode;
+//! use prometheus_push::prometheus_client_crate::PrometheusClientMetricsPusher;
+//! use reqwest::Client;
+//! use url::Url;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let push_gateway: Url = Url::parse("<address to pushgateway>")?;
+//!     let client = Client::new();
+//!     let metrics_pusher = PrometheusClientMetricsPusher::from(client, &push_gateway)?;
+//!     let grouping: HashMap<&str, &str> = HashMap::from([("<label_name>", "<label_value>")]);
+//!     let mut metrics = String::new();
+//!     encode(&mut metrics, &registry)?;
+//!
+//!     metrics_pusher
+//!         .push_all(
+//!             "<your push jobs name>",
+//!             &grouping,
+//!             metrics,
+//!         )
+//!         .await?;
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ### 4. I use `reqwest` and `prometheus-client` crates in a **blocking** fashion
+//!
+//! In your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! prometheus_push = { version = "<version>", default-features = false, features = ["with_reqwest_blocking", "prometheus_client_crate"] }
+//! ```
+//!
+//! ```ignore
+//! use prometheus_client::encoding::text::encode;
+//! use prometheus_push::prometheus_client_crate::PrometheusClientMetricsPusherBlocking;
+//! use reqwest::blocking::Client;
+//! use url::Url;
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let push_gateway: Url = Url::parse("<address to pushgateway>")?;
+//!     let client = Client::new();
+//!     let metrics_pusher = PrometheusClientMetricsPusherBlocking::from(client, &push_gateway)?;
+//!     let grouping: HashMap<&str, &str> = HashMap::from([("<label_name>", "<label_value>")]);
+//!     let mut metrics = String::new();
+//!     encode(&mut metrics, &registry)?;
+//!
+//!     metrics_pusher
+//!         .push_all(
+//!             "<your push jobs name>",
+//!             &grouping,
+//!             metrics,
+//!         )?;
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ### 5. I want to implement everything myself
+//!
+//! In case you wanna implement everything yourself you can do so by implementing the `Push` trait and the `ConvertMetrics` trait.
+//!
+//! #### Implement `Push` yourself
 //!
 //! If you are not using reqwest as an http client you are free to implement the `Push` traits two methods yourself. As a guide you can use the
 //! implementation of the `with_reqwest` feature (see [here](https://github.com/maoertel/prometheus-push/blob/7fe1946dd143f4870beb80e642b0acb7854a3cb8/src/with_reqwest.rs)).
-//!
 //! Basically it is as simple as that.
 //!
 //! ```ignore
-//! use prometheus_push::non_blocking::Push;
+//! use prometheus_push::Push;
 //!
 //! pub struct YourPushClient;
 //!
@@ -60,7 +182,7 @@
 //! }
 //! ```
 //!
-//! ## Implement `ConvertMetrics` yourself
+//! #### Implement `ConvertMetrics` yourself
 //!
 //! In case you want to use another prometheus client implementation you can implement your own type that implements
 //! the `ConvertMetrics` trait to inject it into your instance of `MetricsPusher`.
@@ -97,14 +219,6 @@
 //! - `prometheus_crate`: enables the functionality of the [prometheus](https://crates.io/crates/prometheus) crate
 //! - `prometheus_client_crate`: enables the functionality of the [prometheus-client](https://crates.io/crates/prometheus-client) crate
 //!
-//! ## Integration in your `Cargo.toml`
-//!
-//! Let's say you wanna use it with `reqwest` in an async fashion with the `prometheus` crate, you have to add the following to your `Cargo.toml`:
-//!
-//! ```toml
-//! [dependencies]
-//! prometheus_push = { version = "<version>", default-features = false, features = ["with_reqwest", "prometheus_crate"] }
-//! ```
 
 #[cfg(feature = "blocking")]
 pub mod blocking;


### PR DESCRIPTION
As it was a bit tedious to find out what kind of stuff to use and which features to enable under which circumstances this PR adds documentation to highlight the specifics of the common scenarios, like reqwest & prometheus-client etc.