### PR TITLE
Bump version to `v0.4.4`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus_push"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 authors = ["Mathias Oertel <mathias.oertel@pm.me>"]
 description = "Crate to extend prometheus crates with pushgateway support"


### PR DESCRIPTION
To release a new version to crates.io