### PR TITLE
Update to Rust edition 2024 and dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "prometheus_push"
 version = "0.4.5"
-edition = "2021"
+edition = "2024"
 authors = ["Mathias Oertel <mathias.oertel@pm.me>"]
 description = "Crate to extend prometheus crates with pushgateway support"
 documentation = "https://docs.rs/prometheus_push"
@@ -12,15 +12,15 @@ repository = "https://github.com/maoertel/prometheus-push"
 
 [dependencies]
 url = "2.5"
-thiserror = "1.0"
-prometheus = {version = "0.13", optional = true }
-prometheus-client = { version = "0.22", default-features = false, optional = true }
-reqwest = { version = "0.12", default-features = false, optional = true }
+thiserror = "2.0"
+prometheus = { version = "0.14", optional = true }
+prometheus-client = { version = "0.24", default-features = false, optional = true }
+reqwest = { version = "0.13", default-features = false, optional = true }
 log = { version = "0.4", default-features = false, optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["full"] }
-mockito = "1.4"
+tokio = { version = "1.49", features = ["full"] }
+mockito = "1.7"
 
 [features]
 default = ["non_blocking"]

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -5,10 +5,10 @@ use std::collections::HashMap;
 
 use url::Url;
 
-use crate::error::Result;
-use crate::utils::create_metrics_job_url;
-use crate::utils::PushType;
 use crate::ConvertMetrics;
+use crate::error::Result;
+use crate::utils::PushType;
+use crate::utils::create_metrics_job_url;
 
 /// `MetricsPusher` is a prometheus pushgateway client that holds information about the
 /// address of your pushgateway instance and the [`Push`] client that is used to push

--- a/src/blocking/with_reqwest.rs
+++ b/src/blocking/with_reqwest.rs
@@ -1,14 +1,14 @@
+use reqwest::StatusCode;
 use reqwest::blocking::Body;
 use reqwest::blocking::Client;
 use reqwest::blocking::Response;
 use reqwest::header::CONTENT_TYPE;
-use reqwest::StatusCode;
 use url::Url;
 
 use crate::blocking::Push;
 use crate::error::Result;
-use crate::utils::handle_response;
 use crate::utils::Respond;
+use crate::utils::handle_response;
 
 /// `PushClient` is a wrapper for a blocking `reqwest` http [`Client`] that implements
 /// the [`Push`] trait.

--- a/src/non_blocking.rs
+++ b/src/non_blocking.rs
@@ -3,10 +3,10 @@ use std::future::Future;
 
 use url::Url;
 
-use crate::error::Result;
-use crate::utils::create_metrics_job_url;
-use crate::utils::PushType;
 use crate::ConvertMetrics;
+use crate::error::Result;
+use crate::utils::PushType;
+use crate::utils::create_metrics_job_url;
 
 /// `MetricsPusher` is a prometheus pushgateway client that holds information about the
 /// address of your pushgateway instance and the [`Push`] client that is used to push

--- a/src/prometheus_client_crate.rs
+++ b/src/prometheus_client_crate.rs
@@ -5,10 +5,10 @@ use prometheus_client::encoding::text::encode;
 use prometheus_client::registry::Registry;
 use url::Url;
 
+use crate::ConvertMetrics;
 use crate::error::Result;
 use crate::utils::build_url;
 use crate::utils::validate;
-use crate::ConvertMetrics;
 
 #[cfg(feature = "with_reqwest")]
 use crate::non_blocking::MetricsPusher;
@@ -114,9 +114,9 @@ mod test {
     use mockito::Mock;
     use mockito::Server;
     use mockito::ServerGuard;
-    use prometheus_client::encoding::text::encode;
     use prometheus_client::encoding::EncodeLabelSet;
     use prometheus_client::encoding::EncodeLabelValue;
+    use prometheus_client::encoding::text::encode;
     use prometheus_client::metrics::counter::Counter;
     use prometheus_client::metrics::family::Family;
     use prometheus_client::registry::Registry;

--- a/src/prometheus_crate.rs
+++ b/src/prometheus_crate.rs
@@ -1,18 +1,18 @@
 use std::collections::HashMap;
 
-use prometheus::core::Collector;
-use prometheus::proto::MetricFamily;
 use prometheus::Encoder;
 use prometheus::ProtobufEncoder;
 use prometheus::Registry;
+use prometheus::core::Collector;
+use prometheus::proto::MetricFamily;
 use url::Url;
 
+use crate::ConvertMetrics;
 use crate::error::LabelType;
 use crate::error::PushMetricsError;
 use crate::error::Result;
 use crate::utils::build_url;
 use crate::utils::validate;
-use crate::ConvertMetrics;
 
 #[cfg(feature = "with_reqwest")]
 use crate::non_blocking::MetricsPusher;
@@ -71,18 +71,18 @@ impl PrometheusMetricsConverter {
         for metric_family in metric_families {
             for metric in metric_family.get_metric() {
                 for label_pair in metric.get_label() {
-                    let label_name = label_pair.get_name();
+                    let label_name = label_pair.name();
 
                     if LABEL_NAME_JOB == label_name {
                         return Err(PushMetricsError::contains_label(
-                            metric_family.get_name(),
+                            metric_family.name(),
                             LabelType::Job,
                         ));
                     }
 
                     if grouping.contains_key(label_name) {
                         return Err(PushMetricsError::contains_label(
-                            metric_family.get_name(),
+                            metric_family.name(),
                             LabelType::Grouping(label_name),
                         ));
                     }
@@ -154,12 +154,12 @@ mod test {
     use mockito::Mock;
     use mockito::Server;
     use mockito::ServerGuard;
-    use prometheus::labels;
-    use prometheus::proto::MetricFamily;
     use prometheus::Counter;
     use prometheus::Encoder;
     use prometheus::Opts;
     use prometheus::ProtobufEncoder;
+    use prometheus::labels;
+    use prometheus::proto::MetricFamily;
     use prometheus_crate::PrometheusMetricsPusher;
     use prometheus_crate::PrometheusMetricsPusherBlocking;
     use url::Url;

--- a/src/with_reqwest.rs
+++ b/src/with_reqwest.rs
@@ -1,14 +1,14 @@
-use reqwest::header::CONTENT_TYPE;
 use reqwest::Body;
 use reqwest::Client;
 use reqwest::Response;
 use reqwest::StatusCode;
+use reqwest::header::CONTENT_TYPE;
 use url::Url;
 
 use crate::error::Result;
 use crate::non_blocking::Push;
-use crate::utils::handle_response;
 use crate::utils::Respond;
+use crate::utils::handle_response;
 
 /// `PushClient` is a wrapper for an async `reqwest` http [`Client`] that implements
 /// the [`Push`] trait.


### PR DESCRIPTION
## Summary

- Update Rust edition from 2021 to 2024
- Update thiserror from 1.0 to 2.0
- Update prometheus from 0.13 to 0.14
- Update prometheus-client from 0.22 to 0.24
- Update reqwest from 0.12 to 0.13
- Update tokio (dev) from 1.0 to 1.49
- Update mockito (dev) from 1.4 to 1.7
- Fix deprecated API usage in prometheus 0.14 (`get_name` -> `name`)

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo build --all-features` succeeds
- [x] `cargo test --all-features` passes (4 tests)