### PR TITLE
Bump version to v0.4.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus_push"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 authors = ["Mathias Oertel <mathias.oertel@pm.me>"]
 description = "Crate to extend prometheus crates with pushgateway support"


### PR DESCRIPTION
## Summary

- Bump version from 0.4.5 to 0.4.6

## Test plan

- [x] CI passes