### PR TITLE
chore: update dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ reqwest = { version = "0.13", default-features = false, optional = true }
 log = { version = "0.4", default-features = false, optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.52", features = ["full"] }
 mockito = "1.7"
 
 [features]


### PR DESCRIPTION
## Summary

Updates project dependencies to their latest versions.

- Bump the `tokio` dev-dependency constraint from `1.49` to `1.52` (latest minor).
- Refresh the lockfile (`cargo update`) so all transitive and direct dependencies resolve to their latest compatible releases (e.g. `reqwest` 0.13.4, `url` 2.5.8, `log` 0.4.32, `prometheus-client` 0.24.1, `mockito` 1.7.2, `tokio` 1.52.3).

All other direct dependency constraints (`url`, `thiserror`, `prometheus`, `prometheus-client`, `reqwest`, `log`, `mockito`) already permit their latest releases, so no further manifest changes were needed. `Cargo.lock` is gitignored for this library crate, so only the manifest change is tracked here.

## Verification

- `cargo build --all-features` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅ (no warnings)
- `cargo test --all-features` ✅ (4 passed, 0 failed; 6 integration tests ignored as they require a live pushgateway)
- `cargo fmt --all -- --check` ✅