### PR TITLE
Bump version to v0.4.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus_push"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2024"
 authors = ["Mathias Oertel <mathias.oertel@pm.me>"]
 description = "Crate to extend prometheus crates with pushgateway support"


### PR DESCRIPTION
Bump the crate version from 0.4.6 to 0.4.7 for the next patch release.

This follows merging the dependency-update PR (#20). Tagging `v0.4.7` after this lands triggers the release workflow (verify version, test, publish to crates.io, create GitHub release).